### PR TITLE
Disable selecting future timestamp for footprints

### DIFF
--- a/src/components/DateTimePickerModal.js
+++ b/src/components/DateTimePickerModal.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { DatePicker, TimePicker, Modal } from 'antd';
+import moment from 'moment';
 
 const DateTimePickerModal = (props) => {
 
@@ -7,6 +8,29 @@ const DateTimePickerModal = (props) => {
     visible, onOk, onCancel, okText, date,
     onDateChange, time, onTimeChange,
   } = props;
+
+  function range(start, end) {
+    const result = [];
+    for (let i = start; i < end; i++) {
+      result.push(i);
+    }
+    return result;
+  }
+
+  function disabledDate(current) {
+    // Can not select days before today and today
+    return current && current > moment().endOf('day');
+  }
+
+  function disabledHours() {
+    let currentHour = new Date().getHours();
+    return range(0, 24).splice(currentHour+1) 
+  }
+
+  function disabledMinutes() {
+    let currentMinute = new Date().getMinutes();
+    return range(currentMinute+1, 60);
+  }
 
   return (
     <Modal
@@ -19,10 +43,13 @@ const DateTimePickerModal = (props) => {
       <DatePicker
         value={date}
         onChange={onDateChange}
+        disabledDate={disabledDate}
       />
       <TimePicker
         value={time}
         onChange={onTimeChange}
+        disabledHours={disabledHours}
+        disabledMinutes={disabledMinutes}
       />
     </Modal>
   );


### PR DESCRIPTION
Disabled selecting future time stamps using _antd_ DatePicker and TimePicker API. 
